### PR TITLE
Analyze refresh preflight discriminator panic exploitability

### DIFF
--- a/VULNERABILITY_ANALYSIS.md
+++ b/VULNERABILITY_ANALYSIS.md
@@ -1,0 +1,154 @@
+# Comprehensive Vulnerability Analysis: Refresh Preflight Discriminator Panic
+
+## Executive Summary
+
+**Verdict: SELF-DOS ONLY - NOT EXPLOITABLE AGAINST OTHER USERS**
+
+After conducting a thorough line-by-line analysis of the code and examining Solana's transaction model, I can definitively conclude that this vulnerability is **NOT realistically exploitable** to affect other users on mainnet. It results only in a **self-inflicted denial of service** where attackers can only cause their own transactions to fail.
+
+## Detailed Technical Analysis
+
+### 1. The Vulnerable Code (refresh_ix_utils.rs, lines 91-98)
+
+```rust
+let ix = ix_loader
+    .load_instruction_at(offset)
+    .map_err(|_| LendingError::IncorrectInstructionInPosition)?;
+
+let ix_discriminator: [u8; 8] = ix.data[0..8].try_into().unwrap(); // VULNERABILITY HERE
+
+require_keys_eq!(ix.program_id, crate::id());
+```
+
+**The Issue:** The code attempts to read 8 bytes from instruction data WITHOUT first checking if the data has at least 8 bytes. If `ix.data.len() < 8`, the `unwrap()` will panic.
+
+### 2. Critical Finding: Solana's Transaction Model Prevents Cross-User Exploitation
+
+**Key Facts About Solana Transactions:**
+
+1. **Transaction Atomicity:** Each Solana transaction is atomic and isolated. A transaction either succeeds completely or fails completely.
+
+2. **Transaction Ownership:** Every transaction is created, signed, and submitted by a specific user. The transaction creator has COMPLETE control over ALL instructions within their transaction.
+
+3. **No Cross-Transaction Injection:** It is IMPOSSIBLE for an attacker to inject instructions into another user's transaction. Each transaction is cryptographically signed by its creator, and any modification would invalidate the signature.
+
+4. **Instruction Sysvar:** The `load_instruction_at()` function reads instructions from the CURRENT transaction's instruction list, not from other transactions.
+
+### 3. Attack Scenario Analysis
+
+#### What an Attacker CAN Do:
+```
+1. Create their own transaction with:
+   - A malformed instruction (< 8 bytes data) at the required offset
+   - The target operation (borrow/repay/liquidate/etc.)
+   
+2. Submit this transaction to the network
+
+3. Result: Their OWN transaction panics and fails
+```
+
+#### What an Attacker CANNOT Do:
+```
+1. ❌ Cannot insert instructions into victim's transactions
+2. ❌ Cannot modify other users' pre-existing transactions
+3. ❌ Cannot cause other users' valid transactions to fail
+4. ❌ Cannot block legitimate liquidations from other liquidators
+5. ❌ Cannot freeze other users' funds
+```
+
+### 4. Affected Operations Analysis
+
+The following operations use `check_refresh_ixs!`:
+
+1. **borrow_obligation_liquidity** (v1 only)
+2. **repay_obligation_liquidity** (v1 only)
+3. **withdraw_obligation_collateral** (v1 only)
+4. **deposit_obligation_collateral** (v1 only)
+5. **liquidate_obligation_and_redeem_reserve_collateral** (v1 only)
+6. **deposit_reserve_liquidity_and_obligation_collateral** (v1 only)
+7. **withdraw_obligation_collateral_and_redeem_reserve_collateral** (v1 only)
+8. **socialize_loss** (v1 only)
+
+**Critical Mitigation:** ALL operations have v2 versions that do NOT use `check_refresh_ixs!`:
+
+```rust
+// v1 - vulnerable to self-DoS
+pub fn process_v1(...) -> Result<()> {
+    check_refresh_ixs!(...); // Can panic here
+    process_impl(...)
+}
+
+// v2 - NOT vulnerable
+pub fn process_v2(...) -> Result<()> {
+    process_impl(...)?;
+    refresh_farms!(...); // Different mechanism
+    Ok(())
+}
+```
+
+### 5. Liquidation Scenario - Debunked
+
+**Claim:** "Attacker can block liquidations by front-running with malformed instructions"
+
+**Reality:** 
+- Liquidator A creates a valid liquidation transaction
+- Attacker B creates their own transaction with malformed instruction
+- Attacker B's transaction fails (self-DoS)
+- Liquidator A's transaction executes normally
+- **Result:** No impact on legitimate liquidations
+
+### 6. Code Evidence
+
+From `ix_utils.rs`:
+```rust
+pub struct BpfInstructionLoader<'a, 'info> {
+    pub instruction_sysvar_account_info: &'a AccountInfo<'info>,
+}
+
+impl<'a, 'info> InstructionLoader for BpfInstructionLoader<'a, 'info> {
+    fn load_instruction_at(&self, index: usize) -> Result<Instruction, ProgramError> {
+        load_instruction_at_checked(index, self.instruction_sysvar_account_info)
+    }
+}
+```
+
+This loader reads from the CURRENT transaction's instruction list via the sysvar, not from external sources.
+
+## Conclusion
+
+### Why This is NOT Exploitable on Mainnet:
+
+1. **Transaction Isolation:** Each transaction is isolated and signed by its creator
+2. **No Injection Vector:** Attackers cannot inject instructions into victims' transactions
+3. **Self-Contained Impact:** Panic affects only the transaction containing the malformed instruction
+4. **V2 Functions Available:** All critical operations have non-vulnerable v2 alternatives
+5. **Market Functions Normally:** Other users can continue to liquidate, borrow, repay, etc.
+
+### Real Impact:
+
+- **For Attackers:** Waste their own transaction fees on failed transactions
+- **For Protocol:** No impact on protocol solvency or operations
+- **For Other Users:** Zero impact - they can use v2 functions or properly formatted v1 functions
+- **For Liquidators:** Can continue liquidating normally using either v1 (with proper format) or v2
+
+### Severity Assessment:
+
+- **Manipulate governance:** ❌ No
+- **Theft/insolvency:** ❌ No
+- **Permanent freezing:** ❌ No
+- **Temporary freezing of others' funds:** ❌ No
+- **Self-DoS:** ✅ Yes (only affects attacker's own transactions)
+
+### Recommendation:
+
+While this should be fixed to prevent accidental self-DoS from buggy client implementations, it is NOT a critical vulnerability that can be exploited to harm other users or the protocol on mainnet.
+
+## Fix Recommendation:
+
+```rust
+// Add length check before unwrap
+if ix.data.len() < 8 {
+    return Err(LendingError::IncorrectInstructionInPosition.into());
+}
+let ix_discriminator: [u8; 8] = ix.data[0..8].try_into().unwrap();
+```


### PR DESCRIPTION
Add vulnerability analysis for 'Refresh Preflight Discriminator Panic' to clarify its self-DoS nature.

This analysis debunks claims of cross-user exploitability, concluding that the panic only affects the attacker's own transaction due to Solana's transaction isolation model and the availability of non-vulnerable v2 functions.

---
<a href="https://cursor.com/background-agent?bcId=bc-e778080f-436a-4a65-8801-697a7825e2a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e778080f-436a-4a65-8801-697a7825e2a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

